### PR TITLE
Added url shortener logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import QRPage from "./Pages/QRGenerator/QRPage";
 import Root from "./Pages/Root";
 import TermsAndCondition from "./Pages/TermsAndCondition";
 import Embrays_Helmet from "./Utility/Embrays_Helmet";
+import VisitShortUrl from "./Pages/LinkShortener/VisitShortUrl";
 function App() {
   const { getBlogs } = useBlogContext();
   const location = useLocation();
@@ -40,6 +41,7 @@ function App() {
                 path="/terms-and-conditions"
                 element={<TermsAndCondition />}
               ></Route>
+              <Route path="/url/:shortId" element={<VisitShortUrl />}></Route>
               <Route path="/allblog" element={<ViewAllBlog />}></Route>
               <Route path="/qr-generator" element={<QRPage />}></Route>
               <Route path="/link-shortener" element={<LinkPage />}></Route>

--- a/src/Context/LinkShortContext.jsx
+++ b/src/Context/LinkShortContext.jsx
@@ -17,7 +17,7 @@ function LinkShortContextProvider({ children }) {
   const [copied, setCopied] = useState(false);
   const[loading,setLoading] = useState(false)
   const BASE_URL =
-    "https://gnc114i9rg.execute-api.ap-south-1.amazonaws.com/dev/api/v1/shrink";
+    "https://zgwy7rdhne.execute-api.ap-south-1.amazonaws.com/prod/api/v1/shrink";
 
   async function LinkShortener() {
     setLoading(true)
@@ -32,7 +32,7 @@ function LinkShortContextProvider({ children }) {
         console.log(data);
         const urlId = data.shrinkedUrl.urlId;
         console.log(urlId);
-        const shortURLLink = `${BASE_URL}/go/${urlId}`;
+        const shortURLLink = `https://embraystechnologies.com/url/${urlId}`; // BASE URL should be configured via env file. This will not work on staging envs for now.
         console.log(shortURLLink);
         setShortUrl(shortURLLink);
        setLoading(false)

--- a/src/Pages/LinkShortener/VisitShortUrl.jsx
+++ b/src/Pages/LinkShortener/VisitShortUrl.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom';
+
+
+function VisitShortUrl() {
+    const {shortId} = useParams();
+    const [error, setError] = useState(false)
+
+    useEffect(async () => {
+            let res = await fetch("https://zgwy7rdhne.execute-api.ap-south-1.amazonaws.com/prod/api/v1/shrink/go/" + shortId, {
+                method: "GET"
+            });
+            if(res.status === 200)
+            {
+                const data = await res.json();
+                window.location.href = data.url;
+                return null;
+            }
+            if(!res.ok)
+            {
+                setError(true)
+            }
+    }, [setError])
+
+
+  return (
+    <div className="w-full h-[60vh] flex flex-col items-center justify-center">
+        <div className="text-4xl max-md:text-3xl font-semibold text-Layoutblue mt-5 ">
+            {error || !shortId || shortId === "" ? "Something went wrong" : "Redirecting..."}
+        </div>
+    </div>
+  )
+}
+
+export default VisitShortUrl

--- a/src/Utility/CommonFunctions.js
+++ b/src/Utility/CommonFunctions.js
@@ -1,7 +1,12 @@
 
 export function validateURL(url) {
-    const urlRegex = /^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\w\-,@?^=%&:\/~+#]*)?$/;
-    return urlRegex.test(url);
+    var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+        '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
+    return pattern.test(url);
 }
 
 


### PR DESCRIPTION
Added url shortener logic. A few pointers to keep in mind

- We are currently not using any sorts of env file to keep track of the website's base url, will cause issues as url redirection will output urls with `https://embraystechnologies.com`. To test in staging, replace the base url in the short url output with the staging short url.
- The lambda API is exposed and has no rate limits and/or auth attached. Very insecure as of now, unless we can add some WAF rules via AWS. cc: @ssshreyans26
- Ideally, the shortened url server should be deployed with a different base url (something short, like `https://bit.ly` does. Currently our short urls are not really "short"